### PR TITLE
openai migrate

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,7 +5,9 @@ import xml.etree.ElementTree as ET
 from typing import Dict
 
 import gradio as gr
-import openai
+from openai import OpenAI
+
+client = OpenAI(api_key=open("key.txt").read().strip())
 import pikepdf
 import requests
 import tiktoken
@@ -15,7 +17,6 @@ class GPT4Wrapper:
     def __init__(self, model_name="gpt-3.5-turbo"):
         self.model_name = model_name
         self.tokenizer = tiktoken.encoding_for_model(self.model_name)
-        openai.api_key = open("key.txt").read().strip()
 
     def make_query_args(self, user_str, n_query=1):
         query_args = {
@@ -37,8 +38,8 @@ class GPT4Wrapper:
     def send_query(self, user_str, n_query=1):
         print(f"# tokens sent to GPT: {self.compute_num_tokens(user_str)}")
         query_args = self.make_query_args(user_str, n_query)
-        completion = openai.ChatCompletion.create(**query_args)
-        result = completion.choices[0]["message"]["content"]
+        completion = client.chat.completions.create(**query_args)
+        result = completion.choices[0].message.content
         return result
 
 


### PR DESCRIPTION
"You tried to access openai.ChatCompletion, but this is no longer supported in openai>=1.0.0 - see the README at https://github.com/openai/openai-python for the API.

You can run `openai migrate` to automatically upgrade your codebase to use the 1.0.0 interface."